### PR TITLE
Avoid zero division to calculate rotation axis

### DIFF
--- a/SMPL++/src/smpl/BlendShape.cpp
+++ b/SMPL++/src/smpl/BlendShape.cpp
@@ -806,7 +806,8 @@ torch::Tensor BlendShape::rodrigues(torch::Tensor &theta)
     //
     // rotation angles and axis
     //
-    torch::Tensor angles = torch::norm(theta, 2, {2}, true);// (N, 24, 1)
+    const double eps = 1e-8; // small value to avoid zero division
+    torch::Tensor angles = torch::norm(theta + eps, 2, {2}, true);// (N, 24, 1)
     torch::Tensor axes = theta / angles;// (N, 24, 3)
 
     //


### PR DESCRIPTION
Avoids zero division when rotation is identity. This solution is also taken by the following implementations.
- https://github.com/CalciferZh/SMPL/blob/master/smpl_torch.py#L44-L45
- https://github.com/ahmedosman/STAR/blob/master/star/pytorch/utils.py#L31
